### PR TITLE
Update client.lua

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -181,6 +181,11 @@ AddEventHandler("vorp_walkanim:setAnim", function(animation)
     TriggerServerEvent("vorp_walkanim:setwalk", animation)
 end)
 
+RegisterNetEvent("vorp:SelectedCharacter")
+AddEventHandler("vorp:SelectedCharacter", function(charid)
+    TriggerServerEvent("vorp_walkanim:getwalk")
+end)
+
 AddEventHandler("onResourceStart", function(resourceName)
     if resourceName == GetCurrentResourceName() then
         Wait(10000)


### PR DESCRIPTION
Applied fix for Walk Animations to load automatically on character select

The Walk animations were loaded on resource start auto getting ids of players not on the server yet, applying walk anims to characters that didn't exist yet. Through player testing and reporting we realized it was due to this, so with a trigger on character select this changes and loads on selection